### PR TITLE
FEAT: [002-Diary] CRUD 

### DIFF
--- a/src/main/java/com/zerobase/moy/config/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/moy/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -24,6 +25,7 @@ public class SwaggerConfig {
   public Docket api() {
     return new Docket(DocumentationType.OAS_30)
         .useDefaultResponseMessages(false)
+        .ignoredParameterTypes(AuthenticationPrincipal.class)
         .select()
         .apis(RequestHandlerSelectors.any())
         .paths(PathSelectors.any())

--- a/src/main/java/com/zerobase/moy/config/redis/RedisConfig.java
+++ b/src/main/java/com/zerobase/moy/config/redis/RedisConfig.java
@@ -31,34 +31,38 @@ public class RedisConfig extends CachingConfigurerSupport {
   private Long timeout;
 
   @Bean
-  public LettuceConnectionFactory lettuceConeectionFactory(){
+  public LettuceConnectionFactory lettuceConeectionFactory() {
     LettuceClientConfiguration lettuceClientConfiguration = LettuceClientConfiguration.builder()
         .commandTimeout(Duration.ofMinutes(1))
         .shutdownTimeout(Duration.ZERO)
         .build();
-    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host,port);
-    return new LettuceConnectionFactory(redisStandaloneConfiguration,lettuceClientConfiguration);
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(
+        host, port);
+    return new LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration);
   }
+
   @Bean
-  public RedisTemplate<?,?> redisSignTemplate(){
-    RedisTemplate<String,String> template=new RedisTemplate<>();
+  public RedisTemplate<?, ?> redisSignTemplate() {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
     template.setValueSerializer(new StringRedisSerializer());
     template.setKeySerializer(new StringRedisSerializer());
     template.setConnectionFactory(lettuceConeectionFactory());
     return template;
   }
-  
+
   @Bean
   @Override
-  public CacheManager cacheManager(){
+  public CacheManager cacheManager() {
 
-    RedisCacheManager.RedisCacheManagerBuilder builder=RedisCacheManager
+    RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager
         .RedisCacheManagerBuilder
         .fromConnectionFactory(lettuceConeectionFactory());
 
-    RedisCacheConfiguration configuration=RedisCacheConfiguration.defaultCacheConfig()
-        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+    RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            new GenericJackson2JsonRedisSerializer()))
         .entryTtl(Duration.ofHours(timeout));
     builder.cacheDefaults(configuration);
 

--- a/src/main/java/com/zerobase/moy/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/moy/config/security/JwtAuthenticationFilter.java
@@ -16,7 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
-  private final RedisTemplate<String,String> redisSignTemplate;
+  private final RedisTemplate<String, String> redisSignTemplate;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/zerobase/moy/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/zerobase/moy/config/security/JwtTokenProvider.java
@@ -11,7 +11,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -31,8 +30,8 @@ public class JwtTokenProvider {
   @Value("${jwt.secretKey}")
   private String secretKey;
 
-  private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 5 ;
-  private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60* 24;
+  private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 5;
+  private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24;
   private final UserDetailsService userDetailsService;
 
 
@@ -57,14 +56,15 @@ public class JwtTokenProvider {
     return token;
   }
 
-  public String createRefreshToken(){//rtk
+  public String createRefreshToken() {//rtk
     Date now = new Date();
     String token = Jwts.builder()
         .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION))
         .signWith(SignatureAlgorithm.HS256, secretKey)
         .compact();
-    return  token;
+    return token;
   }
+
   public Authentication getAuthentication(String token) { // token 정보 검사
 
     UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUser(token));
@@ -86,9 +86,10 @@ public class JwtTokenProvider {
     return request.getHeader(ACCESS_TOKEN_HEADER);
   }
 
-  public String resolveRtk(HttpServletRequest request){
+  public String resolveRtk(HttpServletRequest request) {
     return request.getHeader(REFRESH_TOKEN_HEADER);
   }
+
   public boolean validateToken(String token) {
     try { // check validate  with secretKey
       Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
@@ -97,10 +98,11 @@ public class JwtTokenProvider {
       return false;
     }
   }
-  public Long getExpiration(String token){
+
+  public Long getExpiration(String token) {
     Date expiration = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody()
         .getExpiration();
-    long now =new Date().getTime();
-    return expiration.getTime()-now;
+    long now = new Date().getTime();
+    return expiration.getTime() - now;
   }
 }

--- a/src/main/java/com/zerobase/moy/config/security/SecurityConfig.java
+++ b/src/main/java/com/zerobase/moy/config/security/SecurityConfig.java
@@ -16,7 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final JwtTokenProvider jwtTokenProvider;
-  private final RedisTemplate<String,String> redisTemplate;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @Bean
   public SecurityFilterChain defaultFilter(HttpSecurity http) throws Exception {

--- a/src/main/java/com/zerobase/moy/controller/DiaryController.java
+++ b/src/main/java/com/zerobase/moy/controller/DiaryController.java
@@ -1,0 +1,42 @@
+package com.zerobase.moy.controller;
+
+import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diary")
+public class DiaryController {
+
+  private final DiaryService diaryService;
+
+  @PostMapping
+  public ResponseEntity<?> postDiary(@RequestBody DiaryForm form) {
+    return ResponseEntity.ok().body(diaryService.postDiary(form));
+  }
+  @GetMapping("/{id}")
+  public ResponseEntity<?> getDiary(@PathVariable Long id){
+    return ResponseEntity.ok().body(diaryService.getDiary(id));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<?> patchDiary(@PathVariable Long id,@RequestBody DiaryForm form) {
+    return ResponseEntity.ok().body(diaryService.patchDiary(id,form));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<?> deleteDiary(@PathVariable Long id){
+    diaryService.deleteDiary(id);
+    return ResponseEntity.ok().body("삭제 되었습니다.");
+  }
+}

--- a/src/main/java/com/zerobase/moy/controller/DiaryController.java
+++ b/src/main/java/com/zerobase/moy/controller/DiaryController.java
@@ -1,11 +1,13 @@
 package com.zerobase.moy.controller;
 
+import com.zerobase.moy.data.entity.User;
 import com.zerobase.moy.data.model.diary.DiaryForm;
 import com.zerobase.moy.data.model.diary.DiaryResultDto;
 import com.zerobase.moy.service.DiaryService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,30 +26,36 @@ public class DiaryController {
   private final DiaryService diaryService;
 
   @PostMapping
-  public ResponseEntity<?> postDiary(@RequestBody DiaryForm form) {
-    var result=diaryService.postDiary(form);
+
+  public ResponseEntity<?> postDiary(@AuthenticationPrincipal User user,
+      @RequestBody DiaryForm form) {
+    var result = diaryService.postDiary(user, DiaryForm.toDiaryRequestDto(form));
+
     URI location = ServletUriComponentsBuilder.fromCurrentRequest()
         .path("/{id}")
         .build(result.getId());
+
     return ResponseEntity.created(location).body(DiaryResultDto.of(result));
   }
+
   @GetMapping("/{id}")
-  public ResponseEntity<?> getDiary(@PathVariable Long id){
-    var result=diaryService.getDiary(id);
+  public ResponseEntity<?> getDiary(@AuthenticationPrincipal User user, @PathVariable Long id) {
+    var result = diaryService.getDiary(user, id);
     return ResponseEntity.ok().body(DiaryResultDto.of(result));
   }
 
   @PutMapping("/{id}")
-  public ResponseEntity<?> patchDiary(@PathVariable Long id,@RequestBody DiaryForm form) {
+  public ResponseEntity<?> patchDiary(@AuthenticationPrincipal User user, @PathVariable Long id,
+      @RequestBody DiaryForm form) {
 
     URI location = ServletUriComponentsBuilder.fromCurrentRequest().build(id);
-    var result =diaryService.patchDiary(id,form);
+    var result = diaryService.patchDiary(user, id, form);
     return ResponseEntity.created(location).body(DiaryResultDto.of(result));
   }
 
   @DeleteMapping("/{id}")
-  public ResponseEntity<?> deleteDiary(@PathVariable Long id){
-    diaryService.deleteDiary(id);
+  public ResponseEntity<?> deleteDiary(@AuthenticationPrincipal User user, @PathVariable Long id) {
+    diaryService.deleteDiary(user, id);
     return ResponseEntity.accepted().body("삭제 되었습니다.");
   }
 }

--- a/src/main/java/com/zerobase/moy/controller/DiaryController.java
+++ b/src/main/java/com/zerobase/moy/controller/DiaryController.java
@@ -25,23 +25,24 @@ public class DiaryController {
 
   @PostMapping
   public ResponseEntity<?> postDiary(@RequestBody DiaryForm form) {
-    var diary=diaryService.postDiary(form);
+    var result=diaryService.postDiary(form);
     URI location = ServletUriComponentsBuilder.fromCurrentRequest()
         .path("/{id}")
-        .build(diary.getId());
-    return ResponseEntity.created(location).body(DiaryResultDto.of(diary));
+        .build(result.getId());
+    return ResponseEntity.created(location).body(DiaryResultDto.of(result));
   }
   @GetMapping("/{id}")
   public ResponseEntity<?> getDiary(@PathVariable Long id){
-    return ResponseEntity.ok().body(diaryService.getDiary(id));
+    var result=diaryService.getDiary(id);
+    return ResponseEntity.ok().body(DiaryResultDto.of(result));
   }
 
   @PutMapping("/{id}")
   public ResponseEntity<?> patchDiary(@PathVariable Long id,@RequestBody DiaryForm form) {
 
     URI location = ServletUriComponentsBuilder.fromCurrentRequest().build(id);
-
-    return ResponseEntity.created(location).body(diaryService.patchDiary(id,form));
+    var result =diaryService.patchDiary(id,form);
+    return ResponseEntity.created(location).body(DiaryResultDto.of(result));
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/com/zerobase/moy/controller/DiaryController.java
+++ b/src/main/java/com/zerobase/moy/controller/DiaryController.java
@@ -1,7 +1,9 @@
 package com.zerobase.moy.controller;
 
 import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryResultDto;
 import com.zerobase.moy.service.DiaryService;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,17 +14,22 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/diary")
+@RequestMapping("/diaries")
 public class DiaryController {
 
   private final DiaryService diaryService;
 
   @PostMapping
   public ResponseEntity<?> postDiary(@RequestBody DiaryForm form) {
-    return ResponseEntity.ok().body(diaryService.postDiary(form));
+    var diary=diaryService.postDiary(form);
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        .path("/{id}")
+        .build(diary.getId());
+    return ResponseEntity.created(location).body(DiaryResultDto.of(diary));
   }
   @GetMapping("/{id}")
   public ResponseEntity<?> getDiary(@PathVariable Long id){
@@ -31,12 +38,15 @@ public class DiaryController {
 
   @PutMapping("/{id}")
   public ResponseEntity<?> patchDiary(@PathVariable Long id,@RequestBody DiaryForm form) {
-    return ResponseEntity.ok().body(diaryService.patchDiary(id,form));
+
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest().build(id);
+
+    return ResponseEntity.created(location).body(diaryService.patchDiary(id,form));
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<?> deleteDiary(@PathVariable Long id){
     diaryService.deleteDiary(id);
-    return ResponseEntity.ok().body("삭제 되었습니다.");
+    return ResponseEntity.accepted().body("삭제 되었습니다.");
   }
 }

--- a/src/main/java/com/zerobase/moy/controller/SignController.java
+++ b/src/main/java/com/zerobase/moy/controller/SignController.java
@@ -29,15 +29,16 @@ public class SignController {
 
     return ResponseEntity.ok().body(signService.signUp(signUpDto));
   }
+
   @PostMapping("/logout")
-  public ResponseEntity<?> logout(HttpServletRequest req){
+  public ResponseEntity<?> logout(HttpServletRequest req) {
     return ResponseEntity.ok().body(signService.logout(req));
   }
+
   @PostMapping("/reissue")
-  public ResponseEntity<?> reissue(HttpServletRequest req){
+  public ResponseEntity<?> reissue(HttpServletRequest req) {
     return ResponseEntity.ok().body(signService.reissue(req));
   }
-
 
 
 }

--- a/src/main/java/com/zerobase/moy/controller/TestController.java
+++ b/src/main/java/com/zerobase/moy/controller/TestController.java
@@ -1,7 +1,9 @@
 package com.zerobase.moy.controller;
 
+import com.zerobase.moy.data.entity.User;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,10 +11,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/test")
 public class TestController {
+
   @GetMapping()
-  public ResponseEntity<?> test(HttpServletRequest req){
+  public ResponseEntity<?> test(HttpServletRequest req) {
     System.out.println(req);
     return ResponseEntity.ok().body("ok");
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<?> userAthentic(@AuthenticationPrincipal User user) {
+    return ResponseEntity.ok().body(user.getId());
   }
 
 

--- a/src/main/java/com/zerobase/moy/data/entity/BaseEntity.java
+++ b/src/main/java/com/zerobase/moy/data/entity/BaseEntity.java
@@ -5,7 +5,6 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -24,5 +23,5 @@ public class BaseEntity {
   @LastModifiedDate
   private LocalDateTime lastModifiedDate;
 
-  private boolean isDeleted=false;
+  private boolean deleted = false;
 }

--- a/src/main/java/com/zerobase/moy/data/entity/BaseEntity.java
+++ b/src/main/java/com/zerobase/moy/data/entity/BaseEntity.java
@@ -3,6 +3,8 @@ package com.zerobase.moy.data.entity;
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -11,6 +13,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Setter
+@Getter
 public class BaseEntity {
 
   @CreatedDate
@@ -20,4 +24,5 @@ public class BaseEntity {
   @LastModifiedDate
   private LocalDateTime lastModifiedDate;
 
+  private boolean isDeleted=false;
 }

--- a/src/main/java/com/zerobase/moy/data/entity/Diary.java
+++ b/src/main/java/com/zerobase/moy/data/entity/Diary.java
@@ -26,7 +26,7 @@ public class Diary extends BaseEntity {
   @ManyToOne
   private User user;
 
-  private boolean isPublic=false;
+  private boolean isPublic = false;
   private String title;
 
   private String content;

--- a/src/main/java/com/zerobase/moy/data/entity/Diary.java
+++ b/src/main/java/com/zerobase/moy/data/entity/Diary.java
@@ -1,0 +1,35 @@
+package com.zerobase.moy.data.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Diary extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  private User user;
+
+  private boolean isPublic=false;
+  private String title;
+
+  private String content;
+
+
+}

--- a/src/main/java/com/zerobase/moy/data/entity/User.java
+++ b/src/main/java/com/zerobase/moy/data/entity/User.java
@@ -11,10 +11,12 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -37,6 +39,8 @@ public class User extends BaseEntity implements UserDetails {
 
   private String password;
 
+  @OneToMany(mappedBy = "user")
+  List<Diary> diaries;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @Builder.Default

--- a/src/main/java/com/zerobase/moy/data/entity/User.java
+++ b/src/main/java/com/zerobase/moy/data/entity/User.java
@@ -16,7 +16,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/zerobase/moy/data/model/LogoutResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/LogoutResultDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -13,6 +12,7 @@ import lombok.ToString;
 @Builder
 @Getter
 public class LogoutResultDto extends SignUpResultDto {
+
   private boolean success;
 
   private int code;

--- a/src/main/java/com/zerobase/moy/data/model/ReissueResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/ReissueResultDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -12,11 +11,12 @@ import lombok.ToString;
 @ToString
 @Getter
 
-public class ReissueResultDto extends  SignUpResultDto{
+public class ReissueResultDto extends SignUpResultDto {
 
-   TokenDto token;
+  TokenDto token;
+
   @Builder
-  public ReissueResultDto(boolean success, int code, String msg, String atk,String rtk) {
+  public ReissueResultDto(boolean success, int code, String msg, String atk, String rtk) {
     super(success, code, msg);
     this.token = TokenDto.builder()
         .atk(atk)

--- a/src/main/java/com/zerobase/moy/data/model/SignInRequestDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/SignInRequestDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/src/main/java/com/zerobase/moy/data/model/SignInResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/SignInResultDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -17,9 +16,9 @@ public class SignInResultDto extends SignUpResultDto {
   private TokenDto token;
 
   @Builder
-  public SignInResultDto(boolean success, int code, String msg, String atk,String rtk) {
+  public SignInResultDto(boolean success, int code, String msg, String atk, String rtk) {
     super(success, code, msg);
-    this.token= TokenDto.builder()
+    this.token = TokenDto.builder()
         .atk(atk)
         .rtk(rtk)
         .build();

--- a/src/main/java/com/zerobase/moy/data/model/SignUpRequestDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/SignUpRequestDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/src/main/java/com/zerobase/moy/data/model/SignUpResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/SignUpResultDto.java
@@ -1,7 +1,6 @@
 package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/zerobase/moy/data/model/TokenDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/TokenDto.java
@@ -2,7 +2,6 @@ package com.zerobase.moy.data.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,6 +14,7 @@ import lombok.ToString;
 @Getter
 @Setter
 public class TokenDto {
+
   private String atk;
   private String rtk;
 }

--- a/src/main/java/com/zerobase/moy/data/model/diary/DiaryForm.java
+++ b/src/main/java/com/zerobase/moy/data/model/diary/DiaryForm.java
@@ -1,0 +1,27 @@
+package com.zerobase.moy.data.model.diary;
+
+import com.zerobase.moy.data.entity.Diary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@Getter
+public class DiaryForm {
+  private String title;
+  private String content;
+  private String isPublic;
+
+  public static Diary toEntity(DiaryForm form){
+    return Diary.builder()
+        .title(form.getTitle())
+        .content(form.getContent())
+        .isPublic(!form.getIsPublic().isBlank())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/moy/data/model/diary/DiaryRequestDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/diary/DiaryRequestDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.moy.data.model.diary;
 
+import com.zerobase.moy.data.entity.Diary;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,17 +12,17 @@ import lombok.ToString;
 @ToString
 @Builder
 @Getter
-public class DiaryForm {
+public class DiaryRequestDto {
 
   private String title;
   private String content;
-  private String isPublic;
+  private boolean isPublic;
 
-  public static DiaryRequestDto toDiaryRequestDto(DiaryForm form) {
-    return DiaryRequestDto.builder()
-        .title(form.getTitle())
-        .content(form.getContent())
-        .isPublic(!form.getIsPublic().isBlank())
+  public static Diary toEntity(DiaryRequestDto dto) {
+    return Diary.builder()
+        .title(dto.getTitle())
+        .content(dto.getContent())
+        .isPublic(dto.isPublic)
         .build();
   }
 }

--- a/src/main/java/com/zerobase/moy/data/model/diary/DiaryResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/diary/DiaryResultDto.java
@@ -14,11 +14,11 @@ import lombok.ToString;
 @Builder
 @Getter
 @Setter
-public class DiaryResultDto  {
+public class DiaryResultDto {
 
 
-  String title;
-  String content;
+  private String title;
+  private String content;
 
 
   public static DiaryResultDto of(Diary diary) {

--- a/src/main/java/com/zerobase/moy/data/model/diary/DiaryResultDto.java
+++ b/src/main/java/com/zerobase/moy/data/model/diary/DiaryResultDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.moy.data.model.diary;
+
+import com.zerobase.moy.data.entity.Diary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@Getter
+@Setter
+public class DiaryResultDto  {
+
+
+  String title;
+  String content;
+
+
+  public static DiaryResultDto of(Diary diary) {
+    return DiaryResultDto.builder()
+        .title(diary.getTitle())
+        .content(diary.getContent())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/moy/repository/DiaryRepository.java
+++ b/src/main/java/com/zerobase/moy/repository/DiaryRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.moy.repository;
+
+import com.zerobase.moy.data.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary,Long> {
+
+}

--- a/src/main/java/com/zerobase/moy/repository/DiaryRepository.java
+++ b/src/main/java/com/zerobase/moy/repository/DiaryRepository.java
@@ -1,10 +1,12 @@
 package com.zerobase.moy.repository;
 
 import com.zerobase.moy.data.entity.Diary;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DiaryRepository extends JpaRepository<Diary,Long> {
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
+  Optional<Diary> findByIdAndDeletedIsFalse(Long id);
 }

--- a/src/main/java/com/zerobase/moy/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/moy/repository/UserRepository.java
@@ -3,7 +3,6 @@ package com.zerobase.moy.repository;
 import com.zerobase.moy.data.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/zerobase/moy/service/DiaryService.java
+++ b/src/main/java/com/zerobase/moy/service/DiaryService.java
@@ -1,10 +1,11 @@
 package com.zerobase.moy.service;
 
+import com.zerobase.moy.data.entity.Diary;
 import com.zerobase.moy.data.model.diary.DiaryForm;
 import com.zerobase.moy.data.model.diary.DiaryResultDto;
 
 public interface DiaryService {
-  DiaryResultDto postDiary(DiaryForm form);
+  Diary postDiary(DiaryForm form);
 
   DiaryResultDto patchDiary(Long id, DiaryForm form) ;
 

--- a/src/main/java/com/zerobase/moy/service/DiaryService.java
+++ b/src/main/java/com/zerobase/moy/service/DiaryService.java
@@ -1,0 +1,14 @@
+package com.zerobase.moy.service;
+
+import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryResultDto;
+
+public interface DiaryService {
+  DiaryResultDto postDiary(DiaryForm form);
+
+  DiaryResultDto patchDiary(Long id, DiaryForm form) ;
+
+  void deleteDiary(Long id);
+
+  DiaryResultDto getDiary(Long id);
+}

--- a/src/main/java/com/zerobase/moy/service/DiaryService.java
+++ b/src/main/java/com/zerobase/moy/service/DiaryService.java
@@ -1,14 +1,17 @@
 package com.zerobase.moy.service;
 
 import com.zerobase.moy.data.entity.Diary;
+import com.zerobase.moy.data.entity.User;
 import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryRequestDto;
 
 public interface DiaryService {
-  Diary postDiary(DiaryForm form);
 
-  Diary patchDiary(Long id, DiaryForm form) ;
+  Diary postDiary(User user, DiaryRequestDto form);
 
-  void deleteDiary(Long id);
+  Diary patchDiary(User user, Long id, DiaryForm form);
 
-  Diary getDiary(Long id);
+  void deleteDiary(User user, Long id);
+
+  Diary getDiary(User user, Long id);
 }

--- a/src/main/java/com/zerobase/moy/service/DiaryService.java
+++ b/src/main/java/com/zerobase/moy/service/DiaryService.java
@@ -2,14 +2,13 @@ package com.zerobase.moy.service;
 
 import com.zerobase.moy.data.entity.Diary;
 import com.zerobase.moy.data.model.diary.DiaryForm;
-import com.zerobase.moy.data.model.diary.DiaryResultDto;
 
 public interface DiaryService {
   Diary postDiary(DiaryForm form);
 
-  DiaryResultDto patchDiary(Long id, DiaryForm form) ;
+  Diary patchDiary(Long id, DiaryForm form) ;
 
   void deleteDiary(Long id);
 
-  DiaryResultDto getDiary(Long id);
+  Diary getDiary(Long id);
 }

--- a/src/main/java/com/zerobase/moy/service/SignService.java
+++ b/src/main/java/com/zerobase/moy/service/SignService.java
@@ -15,5 +15,6 @@ public interface SignService {
   SignInResultDto signIn(SignInRequestDto dto) throws RuntimeException;
 
   LogoutResultDto logout(HttpServletRequest req);
+
   ReissueResultDto reissue(HttpServletRequest req);
 }

--- a/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
@@ -16,7 +16,7 @@ public class DiaryServiceImpl implements DiaryService {
 
   private final DiaryRepository diaryRepository;
   @Override
-  public DiaryResultDto postDiary(DiaryForm form) {
+  public Diary postDiary(DiaryForm form) {
 
     var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
@@ -24,7 +24,7 @@ public class DiaryServiceImpl implements DiaryService {
     diary.setUser(user);
     Diary savedResult=diaryRepository.save(diary);
 
-    return DiaryResultDto.of(savedResult);
+    return savedResult;
   }
 
   @Override

--- a/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
@@ -1,0 +1,72 @@
+package com.zerobase.moy.service.impl;
+
+import com.zerobase.moy.data.entity.Diary;
+import com.zerobase.moy.data.entity.User;
+import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryResultDto;
+import com.zerobase.moy.repository.DiaryRepository;
+import com.zerobase.moy.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryServiceImpl implements DiaryService {
+
+  private final DiaryRepository diaryRepository;
+  @Override
+  public DiaryResultDto postDiary(DiaryForm form) {
+
+    var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    var diary=DiaryForm.toEntity(form);
+    diary.setUser(user);
+    Diary savedResult=diaryRepository.save(diary);
+
+    return DiaryResultDto.of(savedResult);
+  }
+
+  @Override
+  public DiaryResultDto patchDiary(Long id, DiaryForm form) {
+
+    var diary=diaryRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
+    var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    if(!diary.getUser().equals(user)){
+      throw new RuntimeException("권한이 없습니다.");
+    }
+
+    diary.setContent(form.getContent());
+    diary.setTitle(form.getTitle());
+
+    Diary savedResult=diaryRepository.save(diary);
+
+    return DiaryResultDto.of(savedResult);
+  }
+
+  @Override
+  public void deleteDiary(Long id) {
+    var diary=diaryRepository.findById(id).filter(d->!d.isDeleted()).orElseThrow(()->new IllegalArgumentException("해당하는 포스트가 없습니다."));
+    var user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    if(!diary.getUser().equals(user)){
+      throw new RuntimeException("권한이 없습니다.");
+    }
+    diary.setDeleted(true);
+    diaryRepository.save(diary);
+  }
+
+  @Override
+  public DiaryResultDto getDiary(Long id) {
+    var diary=diaryRepository.findById(id).filter(d->!d.isDeleted()).orElseThrow(()->new IllegalArgumentException("해당하는 포스트가 없습니다."));
+    var user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    if(diary.getUser().equals(user)|| diary.isPublic()){
+      return DiaryResultDto.of(diary);
+    }
+    throw new RuntimeException("비공개 포스트입니다.");
+  }
+
+
+}

--- a/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
@@ -3,9 +3,9 @@ package com.zerobase.moy.service.impl;
 import com.zerobase.moy.data.entity.Diary;
 import com.zerobase.moy.data.entity.User;
 import com.zerobase.moy.data.model.diary.DiaryForm;
-import com.zerobase.moy.data.model.diary.DiaryResultDto;
 import com.zerobase.moy.repository.DiaryRepository;
 import com.zerobase.moy.service.DiaryService;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -22,27 +22,24 @@ public class DiaryServiceImpl implements DiaryService {
 
     var diary=DiaryForm.toEntity(form);
     diary.setUser(user);
-    Diary savedResult=diaryRepository.save(diary);
-
-    return savedResult;
+    return diaryRepository.save(diary);
   }
 
   @Override
-  public DiaryResultDto patchDiary(Long id, DiaryForm form) {
+  public Diary patchDiary(Long id, DiaryForm form) {
 
     var diary=diaryRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
     var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-    if(!diary.getUser().equals(user)){
+    if(!Objects.equals(diary.getUser().getId(), user.getId())){
       throw new RuntimeException("권한이 없습니다.");
     }
 
     diary.setContent(form.getContent());
     diary.setTitle(form.getTitle());
 
-    Diary savedResult=diaryRepository.save(diary);
 
-    return DiaryResultDto.of(savedResult);
+    return diaryRepository.save(diary);
   }
 
   @Override
@@ -58,12 +55,12 @@ public class DiaryServiceImpl implements DiaryService {
   }
 
   @Override
-  public DiaryResultDto getDiary(Long id) {
+  public Diary getDiary(Long id) {
     var diary=diaryRepository.findById(id).filter(d->!d.isDeleted()).orElseThrow(()->new IllegalArgumentException("해당하는 포스트가 없습니다."));
     var user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-    if(diary.getUser().equals(user)|| diary.isPublic()){
-      return DiaryResultDto.of(diary);
+    if(Objects.equals(diary.getUser().getId(), user.getId()) || diary.isPublic()){
+      return diary;
     }
     throw new RuntimeException("비공개 포스트입니다.");
   }

--- a/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/zerobase/moy/service/impl/DiaryServiceImpl.java
@@ -3,11 +3,11 @@ package com.zerobase.moy.service.impl;
 import com.zerobase.moy.data.entity.Diary;
 import com.zerobase.moy.data.entity.User;
 import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryRequestDto;
 import com.zerobase.moy.repository.DiaryRepository;
 import com.zerobase.moy.service.DiaryService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,39 +15,36 @@ import org.springframework.stereotype.Service;
 public class DiaryServiceImpl implements DiaryService {
 
   private final DiaryRepository diaryRepository;
+
   @Override
-  public Diary postDiary(DiaryForm form) {
-
-    var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-    var diary=DiaryForm.toEntity(form);
+  public Diary postDiary(User user, DiaryRequestDto dto) {
+    var diary = DiaryRequestDto.toEntity(dto);
     diary.setUser(user);
     return diaryRepository.save(diary);
   }
 
   @Override
-  public Diary patchDiary(Long id, DiaryForm form) {
+  public Diary patchDiary(User user, Long id, DiaryForm form) {
 
-    var diary=diaryRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
-    var user=  (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    var diary = diaryRepository.findByIdAndDeletedIsFalse(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
 
-    if(!Objects.equals(diary.getUser().getId(), user.getId())){
+    if (!Objects.equals(diary.getUser().getId(), user.getId())) {
       throw new RuntimeException("권한이 없습니다.");
     }
 
     diary.setContent(form.getContent());
     diary.setTitle(form.getTitle());
 
-
     return diaryRepository.save(diary);
   }
 
   @Override
-  public void deleteDiary(Long id) {
-    var diary=diaryRepository.findById(id).filter(d->!d.isDeleted()).orElseThrow(()->new IllegalArgumentException("해당하는 포스트가 없습니다."));
-    var user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  public void deleteDiary(User user, Long id) {
+    var diary = diaryRepository.findByIdAndDeletedIsFalse(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
 
-    if(!diary.getUser().equals(user)){
+    if (!diary.getUser().equals(user)) {
       throw new RuntimeException("권한이 없습니다.");
     }
     diary.setDeleted(true);
@@ -55,13 +52,14 @@ public class DiaryServiceImpl implements DiaryService {
   }
 
   @Override
-  public Diary getDiary(Long id) {
-    var diary=diaryRepository.findById(id).filter(d->!d.isDeleted()).orElseThrow(()->new IllegalArgumentException("해당하는 포스트가 없습니다."));
-    var user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  public Diary getDiary(User user, Long id) {
+    var diary = diaryRepository.findByIdAndDeletedIsFalse(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당하는 포스트가 없습니다."));
 
-    if(Objects.equals(diary.getUser().getId(), user.getId()) || diary.isPublic()){
+    if (Objects.equals(diary.getUser().getId(), user.getId()) || diary.isPublic()) {
       return diary;
     }
+
     throw new RuntimeException("비공개 포스트입니다.");
   }
 

--- a/src/test/java/com/zerobase/moy/service/impl/DiaryServiceImplTest.java
+++ b/src/test/java/com/zerobase/moy/service/impl/DiaryServiceImplTest.java
@@ -1,0 +1,203 @@
+package com.zerobase.moy.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.moy.data.entity.Diary;
+import com.zerobase.moy.data.entity.User;
+import com.zerobase.moy.data.model.diary.DiaryForm;
+import com.zerobase.moy.data.model.diary.DiaryResultDto;
+import com.zerobase.moy.repository.DiaryRepository;
+import com.zerobase.moy.service.DiaryService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+
+@WithMockUser
+@ExtendWith(MockitoExtension.class)
+class DiaryServiceImplTest {
+
+  DiaryService diaryService;
+
+  @Mock
+  DiaryRepository diaryRepository;
+
+  User stub_user = User.builder()
+      .id(1L)
+      .email("Origin")
+      .build();
+
+  @BeforeEach
+  void init() {
+    MockitoAnnotations.openMocks(this);
+    diaryService = new DiaryServiceImpl(diaryRepository);
+
+    Authentication auth = mock(Authentication.class);
+    lenient().when(auth.getPrincipal()).thenReturn(stub_user);
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    lenient().when(securityContext.getAuthentication()).thenReturn(auth);
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @Test
+  @WithUserDetails("test")
+  void post() {
+    User tmp = User.builder().build();
+    System.out.println(SecurityContextHolder.getContext().getAuthentication());
+    var testForm = DiaryForm.builder()
+        .title("목테스트")
+        .content("내용")
+        .build();
+    //given
+
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .build();
+    when(diaryRepository.save(any())).thenReturn(mockDiary);
+    //when
+    var testDto = diaryService.postDiary(testForm);
+    //then
+    assertEquals(testDto.getTitle(), DiaryResultDto.of(mockDiary).getTitle());
+  }
+
+  @Test
+  void patch_pass() {
+    //given
+    var mockForm = DiaryForm.builder()
+        .title("patch")
+        .content("변경")
+        .build();
+
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .user(stub_user)
+        .build();
+    //when
+    Diary diary = new Diary();
+    diary.setId(1L);
+    diary.setTitle("Old Title");
+    diary.setContent("Old Content");
+    diary.setUser(stub_user);
+
+    when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
+    when(diaryRepository.save(diary)).thenReturn(diary);
+
+    DiaryResultDto result = diaryService.patchDiary(1L, mockForm);
+    //then
+    verify(diaryRepository).save(diary);
+    assertEquals(result.getContent(), mockForm.getContent());
+    assertEquals(result.getTitle(), mockForm.getTitle());
+
+  }
+
+  @Test
+  void delete_pass() {
+    //given
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .isPublic(true)
+        .user(stub_user)
+        .build();
+    //when
+    when(diaryRepository.findById(any())).thenReturn(Optional.of(mockDiary));
+    when(diaryRepository.save(mockDiary)).thenReturn(mockDiary);
+    //then
+    diaryService.deleteDiary(1L);
+    assertTrue(mockDiary.isDeleted());
+  }
+  @Test
+  void get_pass() {
+      //given
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .user(stub_user)
+        .build();
+      //when
+    when(diaryRepository.findById(any())).thenReturn(Optional.of(mockDiary));
+      //then
+    var result=diaryService.getDiary(1L);
+    assertEquals(result.getTitle(),mockDiary.getTitle());
+  }
+
+  @Test
+  void get_Diary_notPublic(){
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .isPublic(false)
+        .user(new User())
+        .build();
+    when(diaryRepository.findById(any())).thenReturn(Optional.of(mockDiary));
+
+    assertThrows(RuntimeException.class,() -> diaryService.getDiary(1L));
+  }
+
+  @Test
+  void get_Diary_deleted(){
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .isPublic(false)
+        .user(stub_user)
+        .user(new User())
+        .build();
+    mockDiary.setDeleted(true);
+
+    //when
+
+    //then
+    assertThrows(IllegalArgumentException.class,() -> diaryService.getDiary(1L));
+  }
+  @Test
+  void try_access_others_Diary(){
+    //given
+    var mockDiary = Diary.builder()
+        .id(1L)
+        .title("목테스트")
+        .content("내용")
+        .isPublic(false)
+        .user(stub_user)
+        .user(new User())
+        .build();
+    var mockForm = DiaryForm.builder()
+        .title("patch")
+        .content("변경")
+        .build();
+
+    //when
+    when(diaryRepository.findById(1L)).thenReturn(Optional.ofNullable(mockDiary));
+
+    //
+    assertThrows(RuntimeException.class,() -> diaryService.patchDiary(1L,mockForm));
+  }
+
+
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- Diary(게시물) 의 CRUD를 구현하였습니다. 
- POST(입력), DELETE(삭제), PATCH(전체수정), GET(열람) 이가능합니다.

-POST : 사용자는 입력폼(제목,내용 ,공개여부)로 글을 작성 할수있습니다.
-GET : 사용자는 id값에 해당하는 글을 열람 할 수있습니다. ( 자신이 작성한글에대해서는 공개 여부에 관계없이 열람가능)
- PATCH:  글 id 와 POST와 같은 입력폼(제목,내용,공개여부)로 글을 수정합니다.  
-DELETE : 글 ID 로 해당글을 삭제합니다. ( 데이터베이스상에서 삭제되지않고 삭제 여부만 체크됩니다.)

- PATCH, DELETE : 작성글의 주인이 아니라면 접근이 제한됩니다.
-공통 : 삭제여부(Deleted 칼럼) 값에따라 접근이 불가 할 수있습니다. 

**TO-BE**
- Custom Exception 작성하기 (현재 프로젝트에 Exception 에 대한 응답을 따로 작성하지 않아 Spring이 컨트롤합니다.)
- Validation 적용하기 (User,Diary)  입력 값 검증을 위해 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
- api 테스트는 Swagger Api를 통해 진행하였습니다.
